### PR TITLE
wikipediaの情報を正解した場合表示させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem 'wikipedia-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wikipedia-client (1.17.0)
+      addressable (~> 2.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -254,6 +256,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  wikipedia-client
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,15 +1,19 @@
+require 'wikipedia'
+
 class AnswersController < ApplicationController
   def show
     @answer = Answer.find_by(question_id: params[:id])
     @selected_choice_text = session[:selected_choice_text]
     @select_answer = Choice.find_by(choice_text: @selected_choice_text)
-
+    
     if session[:true_count] && session[:false_count]
       @true_count = session[:true_count]
       @false_count = session[:false_count]
     end
-
+    
     @count = session[:count]
+
+    get_wikipedia_information
     #if @answer.nil?
     #  flash[:error] = '回答が見つかりませんでした。'
     #  redirect_to root_path # 回答がない場合はrootに飛ぶ
@@ -39,5 +43,18 @@ class AnswersController < ApplicationController
     #  redirect_to root_path
     #end
   #end
-  
+
+private
+
+  def get_wikipedia_information
+
+    wiki_data = Wikipedia.find(@select_answer.choice_text)
+    @wiki_link = wiki_data.fullurl
+
+    if wiki_data.summary.blank?
+      @wiki_info = "Wikipediaに情報がありません"
+    else
+      @wiki_info = wiki_data.summary[0, 150] + (wiki_data.summary.length > 150 ? "....." : "")
+    end
+  end
 end

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -8,6 +8,11 @@
           <p class="text-red-500 text-2xl font-bold mt-12">大正解</p>
           <p class="mt-9"><%= @select_answer.choice_text %></p>
           <p class=" text-start px-10 mt-6"><%= @answer.explanation %></p>
+          <div class="align-items flex-end">
+            <p class=" text-center px-10 mt-6 text-blue-700">-------wikipediaの情報-------</p>
+            <p class=" text-start px-10 mt-1"><%= @wiki_info %></p>
+            <p class="text-end px-10 mt-1 text-blue-700"><%= link_to "続きを見る", @wiki_link %></p>
+         </div>
         </div>
 
       <% else %>

--- a/config/initializers/wikipedia.rb
+++ b/config/initializers/wikipedia.rb
@@ -1,0 +1,4 @@
+Wikipedia.configure do |config|
+  config.user_agent('Mozilla/5.0')
+  config.domain('ja.wikipedia.org')
+end


### PR DESCRIPTION
# 追加機能の目的
サービスとして：wikipediaの情報を載せることで、興味関心を引き出す。
開発として：wikiのAPIを使用する経験。

# 仕様概略
クイズに正解した場合に、その答えの情報をwikiから参照し表示する。
wikiに無いものは、表示するデータが無いため、「Wikipediaに情報がありません」とした。

## wikipediaのURLについて
https://ja.wikipedia.org/wiki/タイトル
日本版のwikiは、上記のようにタイトルが直接URLとなる。